### PR TITLE
solved issue with drop_first and match_cols

### DIFF
--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -81,19 +81,19 @@ def test_match_columns_drop_first_remove():
     assert all(res_2.sum() > 0)
     
     
-# def test_match_columns_drop_first_equal():  # todo: this test fails, needs to be fixed
-#     '''
-#     Test match_columns Dummify with drop_first, the category missing is the one dropped
-#     The 2 dataframes should eventually have the same columns
-#     They both drop the first value and the second one needs to have a column of 0 with the last value
-#     No column should be full of 0s
-#     '''
-#     dummifier = tubesml.Dummify(drop_first=True)
-#     res = dummifier.fit_transform(df)
-#     df_2 = df.tail(4)  # the first category is missing
-#     res_2 = dummifier.transform(df_2) 
-#     assert set(res.columns) == set(res_2.columns)
-#     assert all(res_2.sum() > 0)
+def test_match_columns_drop_first_equal(): 
+    '''
+    Test match_columns Dummify with drop_first, the category missing is the one dropped
+    The 2 dataframes should eventually have the same columns
+    They both drop the first value and the second one needs to have a column of 0 with the last value
+    No column should be full of 0s
+    '''
+    dummifier = tubesml.Dummify(drop_first=True)
+    res = dummifier.fit_transform(df)
+    df_2 = df.tail(4)  # the first category is missing
+    res_2 = dummifier.transform(df_2) 
+    assert set(res.columns) == set(res_2.columns)
+    assert all(res_2.sum() > 0)
     
     
 def test_verbose():

--- a/tubesml/dummy.py
+++ b/tubesml/dummy.py
@@ -49,11 +49,11 @@ class Dummify(BaseTransformer):
     
 
     def transform(self, X):
-        if not self.is_fit:
+        if not self.is_fit:  # if it the first time, run it as specified and populate self.columns
             X_tr = pd.get_dummies(X, drop_first=self.drop_first)
             self.columns = X_tr.columns
             self.is_fit = True
-        else:
+        else:  # if it is not the first time, do not use drop_first and let match_cols work
             X_tr = pd.get_dummies(X, drop_first=False) 
             if self.match_cols:
                 X_tr = self._match_columns(X_tr)

--- a/tubesml/dummy.py
+++ b/tubesml/dummy.py
@@ -1,5 +1,5 @@
 __author__ = 'lucabasa'
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 __status__ = 'development'
 
 from tubesml.base import BaseTransformer, self_columns
@@ -11,12 +11,18 @@ class Dummify(BaseTransformer):
     '''
     Wrapper for pd.get_dummies
     It assures that if some column is missing or is new after the first transform, the pipeline won't break
+    
+    To avoid problems with using both drop_first and match_cols, specifically if the dropped category is
+    missing when dummies are created after the first time, we let match_cols to have the role of drop_first
+    if the transformer has been ran already. See test_match_columns_drop_first_equal for an example
+    
     '''
     def __init__(self, drop_first=False, match_cols=True, verbose=False):
         super().__init__()
         self.drop_first = drop_first
         self.match_cols = match_cols
         self.verbose = verbose
+        self.is_fit = False
         
     
     def _match_columns(self, X):
@@ -43,11 +49,13 @@ class Dummify(BaseTransformer):
     
 
     def transform(self, X):
-        X_tr = pd.get_dummies(X, drop_first=self.drop_first)
-        if (len(self.columns) > 0):
+        if not self.is_fit:
+            X_tr = pd.get_dummies(X, drop_first=self.drop_first)
+            self.columns = X_tr.columns
+            self.is_fit = True
+        else:
+            X_tr = pd.get_dummies(X, drop_first=False) 
             if self.match_cols:
                 X_tr = self._match_columns(X_tr)
-        else:
-            self.columns = X_tr.columns
         return X_tr
 


### PR DESCRIPTION
Solves #2 

The solution is to add an attribute to record if the transformer is being used for the first time or not. If it is not the first time, to avoid conflict in the behavior highlighted by the test_match_columns_drop_first_equal, we use drop_first=False and let match_cols to take care of the potential extra columns