### PR TITLE
Fix pdp dataframe creation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ PROJECT_URLS = {
     'Documentation': 'https://tubesml.readthedocs.io/',
     'Source Code': 'https://github.com/lucabasa/tubesML'
 }
-VERSION = '0.5.1'
+VERSION = '0.5.2'
 PYTHON_REQUIRES = ">=3.6"
 
 INSTALL_REQUIRES = [

--- a/tests/test_cvscore.py
+++ b/tests/test_cvscore.py
@@ -60,6 +60,23 @@ def test_cvscore(predict_proba):
         res, _ = tml.cv_score(df_1, y, full_pipe, cv=kfold, predict_proba=predict_proba)
     assert len(record) == 0
     assert len(res) == len(df_1)
+    
+    
+def test_cvscore_nopipe():
+    """
+    Test if the function works without a pipeline
+    """
+    y = df['target']
+    df_1 = df.drop('target', axis=1)
+    
+    kfold = KFold(n_splits=3)
+    
+    full_pipe = LogisticRegression(solver='lbfgs', multi_class='auto')
+    
+    with pytest.warns(None) as record:
+        res, _ = tml.cv_score(df_1, y, full_pipe, cv=kfold, predict_proba=True)
+    assert len(record) == 0
+    assert len(res) == len(df_1)
 
 
 @pytest.mark.parametrize('model', [XGBClassifier(use_label_encoder=False), LGBMClassifier()])

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -188,6 +188,35 @@ def test_get_pdp(model):
     assert {'feat', 'x', 'x_1', 'y'} == set(pdp.columns)
     assert pdp.shape == (100, 4)
     assert pdp['x_1'].isna().all()
+    
+
+@pytest.mark.parametrize('model', [LogisticRegression(solver='lbfgs', multi_class='auto'), 
+                                   DecisionTreeRegressor(),
+                                   XGBClassifier(use_label_encoder=False), 
+                                   LGBMClassifier()])   
+def test_get_pdp_cats(model):
+    """
+    Test basic functioning for various models
+    XGB - Version 1.3.3, not in package requirements
+    LGB - Version 3.1.1, not in package requirements
+    """
+    feat = 'cat'
+    y = df['target']
+    df_1 = df.drop('target', axis=1)
+    df_1['cat'] = [1, 2] * 50
+    
+    full_pipe = Pipeline([('scaler', tml.DfScaler()), 
+                          ('model', model)])
+    
+    full_pipe.fit(df_1, y)
+    
+    with pytest.warns(None) as record:
+        pdp = tml.get_pdp(full_pipe, feat, df_1)
+    assert {'feat', 'x', 'x_1', 'y'} == set(pdp.columns)
+    assert pdp.shape == (100, 4)
+    assert pdp['x_1'].isna().all()
+    
+
 
 
 @pytest.mark.parametrize('model', [LogisticRegression(solver='lbfgs', multi_class='auto'), 

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -213,7 +213,7 @@ def test_get_pdp_cats(model):
     with pytest.warns(None) as record:
         pdp = tml.get_pdp(full_pipe, feat, df_1)
     assert {'feat', 'x', 'x_1', 'y'} == set(pdp.columns)
-    assert pdp.shape == (100, 4)
+    assert pdp.shape == (2, 4)
     assert pdp['x_1'].isna().all()
     
 

--- a/tubesml/model_inspection.py
+++ b/tubesml/model_inspection.py
@@ -256,7 +256,7 @@ def get_pdp(estimator, feature, data, grid_resolution=100):
         df_pdp['y'] = [item for sublist in pdp['average'][0] for item in sublist]
     elif isinstance(feature, str):
         df_pdp = pd.DataFrame({'x': pdp['values'][0], 
-                               'x_1': [np.nan]*grid_resolution, 
+                               'x_1': [np.nan]*len(pdp['values'][0]), 
                                'y': pdp['average'][0]})
     
     df_pdp['feat'] = [feature] * len(df_pdp)


### PR DESCRIPTION
Closes #34 

The solution is to not use grid_resolution to make the empty column, since it would break when the individual values of the features are fewer than the grid_resultion value