### PR TITLE
Remove deprecated warning practice

### DIFF
--- a/tests/test_cvscore.py
+++ b/tests/test_cvscore.py
@@ -1,5 +1,6 @@
 import tubesml as tml
 import pytest
+import warnings
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.tree import DecisionTreeClassifier
@@ -56,9 +57,9 @@ def test_cvscore(predict_proba):
 
     kfold = KFold(n_splits=3)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res, _ = tml.cv_score(df_1, y, full_pipe, cv=kfold, predict_proba=predict_proba)
-    assert len(record) == 0
     assert len(res) == len(df_1)
     
     
@@ -73,9 +74,9 @@ def test_cvscore_nopipe():
     
     full_pipe = LogisticRegression(solver='lbfgs', multi_class='auto')
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res, _ = tml.cv_score(df_1, y, full_pipe, cv=kfold, predict_proba=True)
-    assert len(record) == 0
     assert len(res) == len(df_1)
 
 
@@ -101,9 +102,9 @@ def test_earlystopping(model):
 
     kfold = KFold(n_splits=3)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res, res_dict = tml.cv_score(df_1, y, full_pipe, cv=kfold, early_stopping=5, eval_metric='auc', imp_coef=True)
-    assert len(record) == 0
     assert len(res) == len(df_1)
     assert len(res_dict['iterations']) == 3  # one per fold
 
@@ -133,9 +134,9 @@ def test_cvscore_coef_imp(model):
 
     kfold = KFold(n_splits=3)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res, coef = tml.cv_score(df_1, y, full_pipe, cv=kfold, imp_coef=True)
-    assert len(record) == 0
     assert len(coef['feat_imp']) == df_1.shape[1]  * 2 + 45  # to account for the combinations
 
 
@@ -151,9 +152,9 @@ def test_cvscore_nopipeline(model):
     
     kfold = KFold(n_splits=3)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res, coef = tml.cv_score(df_1, y, model, cv=kfold, imp_coef=True)
-    assert len(record) == 0
     assert len(res) == len(df_1)
     assert len(coef['feat_imp']) == df_1.shape[1]
     
@@ -180,25 +181,25 @@ def test_cvscore_pdp(model):
     full_pipe = Pipeline([('pipe', pipe), 
                           ('model', model)])
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res, pdp_res = tml.cv_score(df_1, y, full_pipe, cv=kfold, pdp=pdp)
-    assert len(record) == 0
     assert set(pdp_res['pdp']['feat']) == set(pdp)
     assert pdp_res['pdp']['mean'].notna().all()
     assert pdp_res['pdp']['std'].notna().all()
 
     
 def test_make_test():
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         train, test = tml.make_test(df, 0.2, 452)
-    assert len(record) == 0
 
 
 def test_strat_test():
     df_1 = df.copy()
     df['cat'] = ['a']*50 + ['b']*50
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         train, test = tml.make_test(df, 0.2, 452, strat_feat='cat')
-    assert len(record) == 0
     assert len(train[train['cat']=='a']) == len(train) / 2
     

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 import pandas as pd
 import numpy as np
 import tubesml
@@ -116,9 +117,9 @@ def test_verbose_change():
     res = dummifier.fit_transform(df)
     with pytest.warns(UserWarning):
         res_2 = dummifier.transform(df_2)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res_2 = dummifier.transform(df_2)
-    assert len(record) == 0
 
     
 def test_dummy_cols():

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 import pandas as pd
 import numpy as np
 import tubesml
@@ -34,16 +35,16 @@ def test_targetencoder_toencode():
     assert res.shape[1] == df.shape[1]
 
 
-@pytest.mark.parametrize("agg_func, warnings", [("mean", None), ('median', None), ('std', None), ('min', None), ('max', None), ('sum', None), ('count', 1)])   
-def test_variousencodings(agg_func, warnings):
+@pytest.mark.parametrize("agg_func, has_warn", [("mean", None), ('median', None), ('std', None), ('min', None), ('max', None), ('sum', None), ('count', 1)])   
+def test_variousencodings(agg_func, has_warn):
     '''
     Test several agg functions, including a forbidden one to check the error
     '''
-    if warnings is None:
-        with pytest.warns(warnings) as record:
+    if has_warn is None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             enc = tubesml.TargetEncoder(agg_func=agg_func)
             res = enc.fit_transform(df, df['b'])
-        assert len(record) == 0
     else:
         with pytest.raises(UserWarning):
             enc = tubesml.TargetEncoder(agg_func=agg_func)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,5 +1,6 @@
 import tubesml as tml
 import pytest
+import warnings
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.datasets import make_classification
@@ -64,9 +65,9 @@ def test_grid_bestestimator(random):
     result, best_param, best_estimator = tml.grid_search(data=df_1, target=y, estimator=full_pipe, 
                                                          param_grid=param_grid, scoring='accuracy', cv=3, random=random)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res = best_estimator.predict(df_1)
-    assert len(record) == 0
     
     
 @pytest.mark.parametrize("random", [False, 20])
@@ -90,10 +91,10 @@ def test_grid_bestestimator_proba(random):
     result, best_param, best_estimator = tml.grid_search(data=df_1, target=y, estimator=full_pipe, 
                                                          param_grid=param_grid, scoring='neg_log_loss', cv=3, random=random)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res = best_estimator.predict(df_1)
-    assert len(record) == 0
-    
+
 
 @pytest.mark.parametrize("random, n_res", [(False, 6), (5, 5)])   
 def test_gridsearch_result(random, n_res):
@@ -143,8 +144,8 @@ def test_gridsearch_nopipeline(random):
     
     param_grid = {'C': np.arange(1, 10)}
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         result, best_param, best_estimator = tml.grid_search(data=df_1, target=y, estimator=model, 
                                                          param_grid=param_grid, scoring='accuracy', cv=3, random=random)
-    assert len(record) == 0
     

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -1,5 +1,6 @@
 import tubesml as tml
 import pytest
+import warnings
 from unittest.mock import patch 
 
 import pandas as pd
@@ -49,9 +50,9 @@ def test_get_coef():
     
     full_pipe.fit(df_1, y)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         coef = tml.get_coef(full_pipe)
-    assert len(record) == 0
     assert len(coef) == df_1.shape[1]
 
 
@@ -72,9 +73,9 @@ def test_feat_imp(model):
     
     full_pipe.fit(df_1, y)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         coef = tml.get_feature_importance(full_pipe)
-    assert len(record) == 0
     assert len(coef) == df_1.shape[1]
 
 
@@ -90,10 +91,10 @@ def test_learning_curves(_):
                           ('logit', LogisticRegression(solver='lbfgs', multi_class='auto'))])
     
     kfold = KFold(n_splits=3)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_learning_curve(estimator=full_pipe, X=df_1, y=y, scoring='accuracy', ylim=(0, 1), cv=kfold,
                             n_jobs=-1, train_sizes=np.linspace(.1, 1.0, 10), title='Title')
-    assert len(record) == 0
     
     
 @patch("matplotlib.pyplot.show")  
@@ -110,10 +111,10 @@ def test_learning_curves_xgb(_):
                                                 use_label_encoder=False))])
     
     kfold = KFold(n_splits=3)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_learning_curve(estimator=full_pipe, X=df_1, y=y, scoring='accuracy', ylim=(0, 1), cv=kfold,
-                            n_jobs=-1, train_sizes=np.linspace(.1, 1.0, 10), title=None)
-    assert len(record) == 0   
+                            n_jobs=-1, train_sizes=np.linspace(.1, 1.0, 10), title=None) 
     
     
 @patch("matplotlib.pyplot.show")
@@ -128,10 +129,10 @@ def test_learning_curves_lgb(_):
                           ('lgb', LGBMClassifier())])
     
     kfold = KFold(n_splits=3)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_learning_curve(estimator=full_pipe, X=df_1, y=y, scoring='accuracy', ylim=None, cv=kfold,
                             n_jobs=-1, train_sizes=np.linspace(.1, 1.0, 10), title=None)
-    assert len(record) == 0
 
 
 @patch("matplotlib.pyplot.show")
@@ -148,9 +149,9 @@ def test_plot_feat_imp(_):
     kfold = KFold(n_splits=3)
     oof, coef = tml.cv_score(df_1, y, full_pipe, kfold, imp_coef=True, predict_proba=False)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_feat_imp(coef['feat_imp'])
-    assert len(record) == 0
     
 
 def test_plot_feat_imp_warning():
@@ -183,7 +184,8 @@ def test_get_pdp(model):
     
     full_pipe.fit(df_1, y)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         pdp = tml.get_pdp(full_pipe, feat, df_1)
     assert {'feat', 'x', 'x_1', 'y'} == set(pdp.columns)
     assert pdp.shape == (100, 4)
@@ -210,14 +212,13 @@ def test_get_pdp_cats(model):
     
     full_pipe.fit(df_1, y)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         pdp = tml.get_pdp(full_pipe, feat, df_1)
     assert {'feat', 'x', 'x_1', 'y'} == set(pdp.columns)
     assert pdp.shape == (2, 4)
     assert pdp['x_1'].isna().all()
     
-
-
 
 @pytest.mark.parametrize('model', [LogisticRegression(solver='lbfgs', multi_class='auto'), 
                                    DecisionTreeRegressor(),
@@ -237,7 +238,8 @@ def test_get_pdp_interaction(model):
     
     full_pipe.fit(df_1, y)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         pdp = tml.get_pdp(full_pipe, feat, df_1)
     assert {'feat', 'x', 'x_1', 'y'} == set(pdp.columns)
     assert pdp.shape == (2500, 4)
@@ -272,9 +274,9 @@ def test_plot_pdp(_):
     kfold = KFold(n_splits=3)
     oof, res = tml.cv_score(df_1, y, full_pipe, kfold, pdp=pdp)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_partial_dependence(res['pdp'])
-    assert len(record) == 0
     
 
 @patch("matplotlib.pyplot.show")      
@@ -293,9 +295,9 @@ def test_plot_pdp_singleplot_y(_):
     full_pipe.fit(df_1, y)
     pdp = tml.get_pdp(full_pipe, df_1.columns[0], df_1)
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         ax = tml.plot_pdp(pdp, df_1.columns[0], '', ax)
-    assert len(record) == 0
     
     
 @patch("matplotlib.pyplot.show")      
@@ -315,7 +317,7 @@ def test_plot_pdp_singleplot_mean(_):
     kfold = KFold(n_splits=3)
     oof, res = tml.cv_score(df_1, y, full_pipe, kfold, pdp=df_1.columns[0])
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         ax = tml.plot_pdp(res['pdp'], df_1.columns[0], '', ax)
-    assert len(record) == 0
     

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -1,5 +1,6 @@
 import tubesml
 import pytest
+import warnings
 import pandas as pd
 import numpy as np
 
@@ -32,9 +33,9 @@ def test_pca():
     Test the transformer works
     '''
     pca = tubesml.DfPCA(n_components=2)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res = pca.fit_transform(df)
-    assert len(record) == 0
     
     
 def test_pca_columns():

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -1,5 +1,6 @@
 import tubesml as tml
 import pytest
+import warnings
 import pandas as pd
 import numpy as np
 
@@ -44,9 +45,9 @@ def test_transformers(add_indicator):
                      ('dummify', tml.Dummify()), 
                      ('pca', tml.DfPCA(n_components=0.9, compress=True))])
     pipe = tml.FeatureUnionDf([('transf', pipe_transf)])
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res = pipe.fit_transform(df, df['target'])
-    assert len(record) == 0
     
 
 @pytest.mark.parametrize("add_indicator", [True, False])
@@ -69,8 +70,8 @@ def test_predictions(add_indicator):
     full_pipe = Pipeline([('pipe', pipe), 
                           ('logit', LogisticRegression(solver='lbfgs', multi_class='auto'))])
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         full_pipe.fit(df_1, y)
         res = full_pipe.predict(df_1)
-    assert len(record) == 0
     

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,5 +1,6 @@
 import tubesml as tml
 import pytest
+import warnings
 from unittest.mock import patch 
 
 from sklearn.linear_model import LogisticRegression
@@ -52,9 +53,9 @@ def test_plot_regression_pred_nohue(_):
     
     oof, _ = tml.cv_score(df_1, y, full_pipe, kfold)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_regression_predictions(data=df_1, true_label=y, pred_label=oof)
-    assert len(record) == 0
 
     
 @patch("matplotlib.pyplot.show") 
@@ -73,9 +74,9 @@ def test_plot_regression_pred_hue(_):
     
     oof, _ = tml.cv_score(df_1, y, full_pipe, kfold)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_regression_predictions(data=df_1, true_label=y, pred_label=oof, hue='cat')
-    assert len(record) == 0
     
 
 @patch("matplotlib.pyplot.show") 
@@ -106,7 +107,8 @@ def test_plot_confusion_matrix_binary(_):
     pred = df['target']
     true = df['target']
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_confusion_matrix(true_label=true, pred_label=pred, ax=None)
 
         
@@ -118,9 +120,9 @@ def test_plot_confusion_matrix_nonbinary(_):
     pred = df_r['target']
     true = df['target']
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_confusion_matrix(true_label=true, pred_label=pred, ax=None)
-    assert len(record) == 0
     
     
 @patch("matplotlib.pyplot.show")       
@@ -138,9 +140,9 @@ def test_plot_classification_probs(_):
     
     oof, _ = tml.cv_score(df_1, y, full_pipe, kfold, predict_proba=True)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_classification_probs(data=df_1, true_label=y, pred_label=oof)
-    assert len(record) == 0
     
     
 @patch("matplotlib.pyplot.show")       
@@ -180,9 +182,9 @@ def test_plot_classification_probs_hue(_):
     
     oof, _ = tml.cv_score(df_1, y, full_pipe, kfold, predict_proba=True)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         tml.plot_classification_probs(data=df_1, true_label=y, pred_label=oof, hue_feat='cat')
-    assert len(record) == 0
     
 
 @patch("matplotlib.pyplot.show")

--- a/tests/test_stacker.py
+++ b/tests/test_stacker.py
@@ -1,5 +1,6 @@
 import tubesml
 import pytest
+import warnings
 import pandas as pd
 import numpy as np
 
@@ -51,14 +52,14 @@ def test_stacker_cls():
     
     kfold = KFold(n_splits=3)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         stk = tubesml.Stacker(estimators=estm, 
                               final_estimator=LogisticRegression(), 
                               cv=kfold)
         stk.fit(df_1, y)
         _ = stk.predict(df_1)
         _ = stk.predict_proba(df_1)
-    assert len(record) == 0
     
     
 def test_stacker_reg():
@@ -73,13 +74,13 @@ def test_stacker_reg():
     
     kfold = KFold(n_splits=3)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         stk = tubesml.Stacker(estimators=estm, 
                               final_estimator=DecisionTreeRegressor(), 
                               cv=kfold)
         stk.fit(df_1, y)
         _ = stk.predict(df_1)
-    assert len(record) == 0
     
 
 def test_stacker_pipelines():
@@ -96,14 +97,14 @@ def test_stacker_pipelines():
     
     kfold = KFold(n_splits=3)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         stk = tubesml.Stacker(estimators=estm, 
                               final_estimator=pipe2, 
                               cv=kfold)
         stk.fit(df_1, y)
         _ = stk.predict(df_1)
         _ = stk.predict_proba(df_1)
-    assert len(record) == 0
 
 
 def test_importances():
@@ -139,15 +140,14 @@ def test_hybrid_params():
     
     kfold = KFold(n_splits=3)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         stk = tubesml.Stacker(estimators=estm, 
                             final_estimator=DecisionTreeClassifier(), 
                             cv=kfold, lay1_kwargs={'logit': {'predict_proba': True}})
         stk.fit(df_1, y)
         _ = stk.predict(df_1)
         _ = stk.predict_proba(df_1)
-        
-    assert len(record) == 0
     
 
 def test_early_stopping():
@@ -162,7 +162,8 @@ def test_early_stopping():
     
     kfold = KFold(n_splits=3)
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         stk = tubesml.Stacker(estimators=estm, 
                             final_estimator=DecisionTreeClassifier(), 
                             cv=kfold, lay1_kwargs={'xgb': {'predict_proba': True, 
@@ -173,8 +174,7 @@ def test_early_stopping():
         stk.fit(df_1, y)
         _ = stk.predict(df_1)
         _ = stk.predict_proba(df_1)
-        
-    assert len(record) == 0
+
     assert stk._estimators[0].n_estimators < 10000
     assert stk._estimators[1].n_estimators < 10000
     
@@ -245,11 +245,11 @@ def test_gridsearch_stacker_simple(scoring):
     
     param_grid = {'final_estimator__max_depth': [3,4,5]}
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         result, best_param, best_estimator = tubesml.grid_search(data=df_1, target=y, estimator=stk, 
                                                          param_grid=param_grid, scoring=scoring, cv=3)
         
-    assert len(record) == 0
     
     
 @pytest.mark.parametrize("scoring", ['accuracy', 'neg_log_loss'])   
@@ -273,11 +273,11 @@ def test_gridsearch_stacker_pipeline(scoring):
     
     param_grid = {'model__final_estimator__max_depth': [3,4,5]}
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         result, best_param, best_estimator = tubesml.grid_search(data=df_1, target=y, estimator=pipe, 
                                                          param_grid=param_grid, scoring=scoring, cv=3)
         
-    assert len(record) == 0
     
     
 @pytest.mark.parametrize("passthrough", [True, False, 'hybrid'])   
@@ -304,11 +304,11 @@ def test_gridsearch_stacker_passthrough(passthrough):
     
     param_grid = {'model__final_estimator__max_depth': [3,4,5]}
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         result, best_param, best_estimator = tubesml.grid_search(data=df_1, target=y, estimator=pipe, 
                                                          param_grid=param_grid, scoring='neg_log_loss', cv=3)
-        
-    assert len(record) == 0
+
 
     
 @pytest.mark.parametrize("predict_proba", [True, False])
@@ -328,9 +328,9 @@ def test_cv_score_stacker_simple(predict_proba):
                             final_estimator=DecisionTreeClassifier(), 
                             cv=kfold, lay1_kwargs={'logit': {'predict_proba': True}})
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res, _ = tubesml.cv_score(df_1, y, stk, cv=kfold, predict_proba=predict_proba)
-    assert len(record) == 0
     
     
 @pytest.mark.parametrize("predict_proba", [True, False])
@@ -353,9 +353,9 @@ def test_cv_score_stacker_simple(predict_proba):
     
     pipe = Pipeline([('scl', tubesml.DfScaler()), ('model', stk)])
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res, _ = tubesml.cv_score(df_1, y, stk, cv=kfold, predict_proba=predict_proba)
-    assert len(record) == 0
     
     
 @pytest.mark.parametrize("passthrough", [True, False, 'hybrid'])
@@ -381,6 +381,6 @@ def test_cv_score_stacker_passthrough(passthrough):
     
     pipe = Pipeline([('scl', tubesml.DfScaler()), ('model', stk)])
     
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res, _ = tubesml.cv_score(df_1, y, stk, cv=kfold, predict_proba=True)
-    assert len(record) == 0

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,5 +1,6 @@
 import tubesml
 import pytest
+import warnings
 import pandas as pd
 import numpy as np
 
@@ -75,9 +76,9 @@ def test_featun_nowarnings():
     cat_pipe = Pipeline([('cat', tubesml.DtypeSel(dtype='category'))])
     tot_pipe = tubesml.FeatureUnionDf(transformer_list=[('cat', cat_pipe), 
                                                         ('num', num_pipe)])
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         res = tot_pipe.fit_transform(df)
-    assert len(record) == 0
     
 
 def test_featun_transformers():


### PR DESCRIPTION
Pytest deprecated how we were testing for the 'no warning raised case'. Now fixed across all the tests